### PR TITLE
Add Initial LDAP Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # EctoLdap
 
-**TODO: Add description**
+**Ecto Adapter for LDAP**
+
+## TODO
+1.  Implement connection pool upon adapter startup
+2.  Remove all hardcoding in favor of configuration
+3.  Migrate existing `eldap` wrapper into EctoLdap to remove dependency on `:exldap`
+
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed as:
+If [available in Hex](https://hex.pm/docs/publish) (currently unavailable), the package can be installed as:
 
   1. Add ecto_ldap to your list of dependencies in `mix.exs`:
 
@@ -17,4 +23,3 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
         def application do
           [applications: [:ecto_ldap]]
         end
-

--- a/chuck.exs
+++ b/chuck.exs
@@ -1,0 +1,11 @@
+# Helper script for iex testing
+# $ iex -S mix
+# iex(1)> import_file "chuck.exs"
+
+import Supervisor.Spec
+tree = [worker(Ecto.Ldap.TestRepo, [])]
+opts = [name: Ecto.Ldap.Sup, strategy: :one_for_one]
+Supervisor.start_link(tree, opts)
+
+alias Ecto.Ldap.TestRepo
+alias Ecto.Ldap.TestModel

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,4 +2,13 @@ use Mix.Config
 
 config :ecto, Ecto.Ldap.TestRepo,
        adapter: Ecto.Ldap.Adapter,
-       url: "ldap+ssl://ldap.puppetlabs.com/dc=com,dc=puppetlabs,ou=users"
+       url: "ldap+ssl://ldap.puppetlabs.com/dc=com,dc=puppetlabs,ou=users",
+       pool_size: 1
+
+config :exldap, :settings,
+       server: "LDAP Server goes here",
+       base: "dc=puppetlabs,dc=com",
+       port: 636,
+       ssl: true,
+       user_dn: "user_goes_here",
+       password: "password_goes_here"

--- a/lib/ecto_ldap/adapter.ex
+++ b/lib/ecto_ldap/adapter.ex
@@ -1,6 +1,7 @@
 defmodule Ecto.Ldap.Adapter do
   use GenServer
   @behaviour Ecto.Adapter
+
   def execute(repo, query_metadata, prepared, params, preprocess, options) do
     IO.inspect(repo)
     IO.inspect(query_metadata)
@@ -8,6 +9,15 @@ defmodule Ecto.Ldap.Adapter do
     IO.inspect(params)
     IO.inspect(preprocess)
     IO.inspect(options)
+
+    {:ok, connection} = Exldap.connect
+    {:ok, search_results} = Exldap.search_field(
+        connection,
+        "ou=users,dc=puppetlabs,dc=com",
+        "mail",
+        'jeff.weiss@puppetlabs.com')
+
+    IO.inspect search_results
 
     # :eldap.search(repo.something, prepared)
     # transform results into list of lists
@@ -17,7 +27,7 @@ defmodule Ecto.Ldap.Adapter do
 
   def prepare(:all, query) do
     IO.inspect(query)
-    search_options = 
+    search_options =
       [ {:base, "ou=users,dc=puppetlabs,dc=com"},
         {:filter, :eldap.equalityMatch(:mail, 'jeff.weiss@puppetlabs.com')},
         {:scope, :eldap.wholeSubtree()},
@@ -25,14 +35,16 @@ defmodule Ecto.Ldap.Adapter do
       ]
     {:nocache, search_options}
   end
+
   def prepare(:update_all, query) do
   end
+
   def prepare(:delete_all, query) do
     raise ArgumentError, "We don't delete"
   end
 
   defmacro __before_compile__(env) do
-    quote do 
+    quote do
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule EctoLdap.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger, :ecto]]
+    [applications: [:logger, :ecto, :exldap]]
   end
 
   # Dependencies can be Hex packages:
@@ -29,6 +29,7 @@ defmodule EctoLdap.Mixfile do
   defp deps do
     [
       {:ecto, "~> 1.1"},
+      {:exldap, "~> 0.1"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,4 @@
 %{"decimal": {:hex, :decimal, "1.1.1"},
   "ecto": {:hex, :ecto, "1.1.1"},
+  "exldap": {:hex, :exldap, "0.1.1"},
   "poolboy": {:hex, :poolboy, "1.5.1"}}


### PR DESCRIPTION
Prior to this commit, there was no mechanism by which a live LDAP test
could be conducted.  This commit introduces a dependency on `exldap` for
the purposes of testing the Ecto LDAP Adapter.  Please note, user
credentials must be provided in the `dev.exs` configuration file.

Additionally, this commit provides a script to initialize the IEx shell
for the purposes of testing the adapter.  The README.md has also been
updated to track outstanding work and to remove default project text.
