### PR TITLE
Provide `query_metadata` to query execution

### DIFF
--- a/chuck.exs
+++ b/chuck.exs
@@ -7,5 +7,9 @@ tree = [worker(Ecto.Ldap.TestRepo, [])]
 opts = [name: Ecto.Ldap.Sup, strategy: :one_for_one]
 Supervisor.start_link(tree, opts)
 
+require Ecto.Query
+
+alias Ecto.Ldap.Adapter
 alias Ecto.Ldap.TestRepo
-alias Ecto.Ldap.TestModel
+alias Ecto.Ldap.TestUser
+alias Ecto.Query

--- a/lib/ecto_ldap/adapter.ex
+++ b/lib/ecto_ldap/adapter.ex
@@ -1,47 +1,8 @@
 defmodule Ecto.Ldap.Adapter do
   use GenServer
+  require IEx
+
   @behaviour Ecto.Adapter
-
-  def execute(repo, query_metadata, prepared, params, preprocess, options) do
-    IO.inspect(repo)
-    IO.inspect(query_metadata)
-    IO.inspect(prepared)
-    IO.inspect(params)
-    IO.inspect(preprocess)
-    IO.inspect(options)
-
-    {:ok, connection} = Exldap.connect
-    {:ok, search_results} = Exldap.search_field(
-        connection,
-        "ou=users,dc=puppetlabs,dc=com",
-        "mail",
-        'jeff.weiss@puppetlabs.com')
-
-    IO.inspect search_results
-
-    # :eldap.search(repo.something, prepared)
-    # transform results into list of lists
-
-    :wat
-  end
-
-  def prepare(:all, query) do
-    IO.inspect(query)
-    search_options =
-      [ {:base, "ou=users,dc=puppetlabs,dc=com"},
-        {:filter, :eldap.equalityMatch(:mail, 'jeff.weiss@puppetlabs.com')},
-        {:scope, :eldap.wholeSubtree()},
-        {:attributes, [:dn, :mobile]}
-      ]
-    {:nocache, search_options}
-  end
-
-  def prepare(:update_all, query) do
-  end
-
-  def prepare(:delete_all, query) do
-    raise ArgumentError, "We don't delete"
-  end
 
   defmacro __before_compile__(env) do
     quote do
@@ -55,4 +16,127 @@ defmodule Ecto.Ldap.Adapter do
   def init(opts) do
     {:ok, opts}
   end
+
+  def execute(repo, query_metadata, prepared, params, preprocess, options) do
+    IO.inspect(repo)
+    IO.inspect(query_metadata)
+    IO.inspect(prepared)
+    IO.inspect(params)
+    IO.inspect(preprocess)
+    IO.inspect(options)
+
+    {:ok, connection} = Exldap.connect
+    # IEx.pry
+    {:ok, search_results} = Exldap.search_field(
+        connection,
+        prepared[:base],
+        prepared[:filter_parameter],
+        prepared[:filter_criteria])
+
+    IO.inspect search_results
+
+    # :eldap.search(repo.something, prepared)
+    # transform results into list of lists
+
+    :wat
+  end
+
+  def prepare(:all, query) do
+    # ou                    == table (`FROM` statement)
+    # dc=puppetlabs,dc=com  == database
+    # :attributes           == SELECT
+    # :filter               == WHERE (equalityMatch / search terms)
+
+    # IO.puts "I'm being prepared!"
+    IO.inspect(query)
+    # IEx.pry
+    query_metadata = 
+      [
+        :construct_filter,
+        :construct_base,
+        :construct_scope,
+      ]
+      |> Enum.map(&(apply(__MODULE__, &1, [query])))
+      |> Enum.filter(&(&1))
+
+
+      [ {:base, construct_base(query.from)},
+        {:filter, construct_filter(query.wheres)},
+        {:scope, construct_scope},
+        {:attributes, construct_attributes(query.select)},
+        {:filter_parameter, extract_parameter(query.wheres)},
+        {:filter_criteria, extract_criteria(query.wheres)}
+      ]
+    {:nocache, query_metadata}
+  end
+
+  def construct_base(%{from: from}) do
+    {:base, "ou=" <> ou <> "," <> base}
+  end
+  def constuct_base(_), do: {:base, base}
+
+  defp base, do: Keyword.get(Application.get_env(:exldap, :settings), :base)
+
+  def construct_filter(%{wheres: wheres}) when is_list(wheres) do 
+    filter_term = 
+      wheres
+      |> Stream.map(&Map.get(&1, :expr))
+      |> Enum.map(&translate_ecto_lisp_to_eldap_filter/1)
+      |> :eldap.and
+    {:filter, filter_term}
+  end
+  def construct_filter(_), do: nil
+
+  def extract_parameter(wheres) do
+    [{{_, _, [_ | parameter]}, _, _} | _] = extract_array(wheres)
+    case parameter do
+      {:&, [], [0]} -> []
+      _ -> to_string(hd(parameter))
+    end
+  end
+
+  def extract_criteria([]), do: []
+  def extract_criteria(wheres), do: hd(tl(extract_array(wheres)))
+
+  def extract_array([%Ecto.Query.QueryExpr{expr: {_, _, array}} | _tail]), do: array
+
+  def construct_scope, do: {:scope, :eldap.wholeSubtree}
+
+  def construct_attributes(%Ecto.Query.SelectExpr{fields: fields}) do
+    case fields do
+      [{:&, [], [0]}] -> []
+      _ -> fields
+    end
+  end
+
+  def prepare(:update_all, query), do: raise UndefinedFunctionError, "Update is currently unsupported"
+  def prepare(:delete_all, query), do: raise UndefinedFunctionError, "Delete is currently unsupported"
+
+  def translate_ecto_lisp_to_eldap_filter({:or, _, list_of_subexpressions}) do
+    list_of_subexpressions
+    |> Enum.map(&translate_ecto_lisp_to_eldap_filter/1)
+    |> :eldap.or
+  end
+  def translate_ecto_lisp_to_eldap_filter({:and, _, list_of_subexpressions}) do
+    list_of_subexpressions
+    |> Enum.map(&translate_ecto_lisp_to_eldap_filter/1)
+    |> :eldap.and
+  end
+  def translate_ecto_lisp_to_eldap_filter({:==, _, [value1, value2]}) do
+    :eldap.equalityMatch(translate_value(value1), translate_value(value2))
+  end
+  def translate_ecto_lisp_to_eldap_filter({:>=, _, [value1, value2]}) do
+    :eldap.greaterOrEqual(translate_value(value1), translate_value(value2))
+  end
+  def translate_ecto_lisp_to_eldap_filter({:<=, _, [value1, value2]}) do
+    :eldap.lessOrEqual(translate_value(value1), translate_value(value2))
+  end
+
+  def translate_value({{:., [], [{:&, [], [0]}, attribute]}, [], []}) when is_atom(attribute) do
+    attribute
+    |> to_string
+    |> to_char_list
+  end
+  def translate_value(%Ecto.Query.Tagged{value: value}), do: value
+  def translate_value(other), do: other
 end

--- a/lib/ecto_ldap/test_user.ex
+++ b/lib/ecto_ldap/test_user.ex
@@ -1,0 +1,11 @@
+defmodule Ecto.Ldap.TestUser do
+  use Ecto.Schema
+
+  schema "users" do
+    field :dn, :string
+    field :objectClass, :string
+    field :mail, :string
+    field :mobile, :string
+  end
+
+end


### PR DESCRIPTION
Prior to this commit, hardcoding was applied to the `execute` method for
testing purposes.  These changes remove some hardcoding in favor of
query arguments provided to the repository.  By doing this, the
repository moves closer toward supporing traditional Ecto operations.

Additionally, a new testing type, `TestUser` has been introduced.  It
mirrors the model currently being tested against the LDAP database.

Please note:  The query metadata provided to the `execute` method are
not in their final state.  Extra parameters are currently being provided
to simplify the API call to `Exldap`.  Once `:eldap` is fully
integrated, the `:filter_parameter` and `:filter_criteria` entries will
be removed.  In its place, `:filter` will hold the appropriate data for
passing filter information directly to `:eldap`.
