### PR TITLE
Add Repo.get capability

### DIFF
--- a/test/support/test_user.ex
+++ b/test/support/test_user.ex
@@ -1,12 +1,19 @@
 defmodule Ecto.Ldap.TestUser do
   use Ecto.Schema
+  import Ecto.Changeset
 
+  @primary_key {:dn, :string, []}
   schema "users" do
-    field :dn, :string
     field :objectClass, :string
     field :mail, :string
     field :mobile, :string
     field :sn, :string
+  end
+
+  def changeset(model, params \\ :empty) do
+    model
+    |> cast(params, ~w(dn), ~w(objectClass mail mobile sn))
+    |> unique_constraint(:dn)
   end
 
 end


### PR DESCRIPTION
Prior to this commit, the `Ecto.Ldap.Adapter` did not properly handle
Ecto's `Repo.get` command.  When issuing the command, the `:eldap` calls
received an unexpected struct with insufficient information to complete
the retrieval from LDAP.

With this change, it is now possible to query a single
user based on their LDAP distinguished name (dn).

This commit handles the unique data structure received by
`Ecto.Ldap.Adapter` and invokes a new search behaviour accordingly.
Specifically, if a matching pattern is found, the `:eldap` calls
structure the `search` value based on the explicit `dn` provided by
the consumer.

e.g.
`TestRepo.get TestUser "uid=bar,ou=users,dc=company,dc=com"`

Additionally, this commit introduces the `primary_key` concept to the
`TestUser` module.  The `primary_key` for LDAP's purposes will be the
distinguished name `dn` attribute.
