### PR TITLE
Clean up config/dev.exs

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,13 +2,10 @@ use Mix.Config
 
 config :ecto, Ecto.Ldap.TestRepo,
        adapter: Ecto.Ldap.Adapter,
-       url: "ldap+ssl://ldap.puppetlabs.com/dc=com,dc=puppetlabs,ou=users",
-       pool_size: 1
-
-config :exldap, :settings,
-       server: "LDAP Server goes here",
-       base: "dc=puppetlabs,dc=com",
+       hostname: "HOSTNAME_GOES_HERE",
+       base: "BASE_GOES_HERE",
        port: 636,
        ssl: true,
-       user_dn: "user_goes_here",
-       password: "password_goes_here"
+       user_dn: "USER_DN_GOES_HERE",
+       password: "PASSWORD_GOES_HERE",
+       pool_size: 1


### PR DESCRIPTION
Prior to this commit, there were configuration artifacts from `:exldap`
left in the `config/dev.exs` file.  This commit removes those references
and provides a cleaner set of configuration for future use.
