### PR TITLE
Add Repo.update capability

### DIFF
--- a/lib/ecto_ldap/adapter.ex
+++ b/lib/ecto_ldap/adapter.ex
@@ -26,6 +26,10 @@ defmodule Ecto.Ldap.Adapter do
     GenServer.call(__MODULE__, {:search, search_options})
   end
 
+  def update(schema_meta, fields, filters) do
+    GenServer.call(__MODULE__, {:update, schema_meta, fields, filters})
+  end
+
   def base do
     GenServer.call(__MODULE__, :base)
   end
@@ -42,6 +46,29 @@ defmodule Ecto.Ldap.Adapter do
     ldap_disconnect(handle)
 
     {:reply, search_response, state}
+  end
+
+  def handle_call({:update, schema_meta, fields, filters}, _from, state) do
+
+    {:ok, handle} = ldap_connect(state)
+    [base] = Keyword.get(filters, :dn)
+
+    modify_operations =
+      for {attribute, value} <- fields do
+        generate_modify_operation(attribute, value)
+      end
+
+    result = :eldap.modify(handle, base, modify_operations)
+    ldap_disconnect(handle)
+
+    {:reply, result, state}
+  end
+
+  def generate_modify_operation(attribute, []) do
+    :eldap.mod_replace(convert_to_erlang(attribute), [])
+  end
+  def generate_modify_operation(attribute, value) when is_list(value) do
+    :eldap.mod_replace(convert_to_erlang(attribute), value)
   end
 
   def handle_call(:base, _from, state) do
@@ -295,10 +322,23 @@ defmodule Ecto.Ldap.Adapter do
     split_and_not_nil(t, count - 1, false, [h|acc])
   end
 
+  def update(repo, schema_meta, fields, filters, _autogen_id, returning, options) do
+    case update(schema_meta, fields, filters) do
+      :ok ->
+        {:ok, fields}
+      error ->
+        IO.inspect error
+        {:invalid, []}
+    end
+  end
+
   def load(:id, value), do: {:ok, value}
   def load(:string, value), do: {:ok, convert_from_erlang(value)}
+  def load({:array, :string}, []), do: {:ok, []}
+  def load({:array, :string}, value), do: {:ok, convert_from_erlang(value)}
 
-  def dump(:string, value), do: {:ok, convert_to_erlang(value)}
+  def dump(:string, value) when is_list(value), do: {:ok, convert_to_erlang(value)}
+  def dump(:string, value), do: {:ok, [convert_to_erlang(value)]}
   def dump(_, value), do: {:ok, convert_to_erlang(value)}
 
   def convert_from_erlang(list=[head|_]) when is_list(head), do: Enum.map(list, &convert_from_erlang/1)

--- a/test/support/test_user.ex
+++ b/test/support/test_user.ex
@@ -5,15 +5,17 @@ defmodule Ecto.Ldap.TestUser do
   @primary_key {:dn, :string, autogenerate: false}
   schema "users" do
     field :objectClass, :string
+    field :languages, {:array, :string}
     field :mail, :string
     field :mobile, :string
+    field :skills, {:array, :string}
     field :sn, :string
     field :uid, :string
   end
 
   def changeset(model, params \\ :empty) do
     model
-    |> cast(params, ~w(dn), ~w(objectClass mail mobile sn uid))
+    |> cast(params, ~w(dn), ~w(languages objectClass mail mobile skills sn uid))
     |> unique_constraint(:dn)
   end
 


### PR DESCRIPTION
Prior to this commit, the `ecto_ldap` adapter did not support the
ability to update attributes on an LDAP object.  This commit introduces
the necessary code to enable LDAP object attribute updates via Ecto.
With these changes, consumers of the `ecto_ldap` adapter will be able to
invoke the `Repo.update changeset` command for the purposes of updating
selected attributes on a given LDAP object.
