### PR TITLE
Handle list-based select criteria

### DIFF
--- a/lib/ecto_ldap/adapter.ex
+++ b/lib/ecto_ldap/adapter.ex
@@ -259,6 +259,10 @@ defmodule Ecto.Ldap.Adapter do
   defp translate_ecto_lisp_to_eldap_filter({op, [], [value1, {:^, [], [idx,len]}]}, params) do
     translate_ecto_lisp_to_eldap_filter({op, [], [value1, Enum.slice(params, idx, len)]}, params)
   end
+  # {:in, [], [{:^, [], [0]}, {{:., [], [{:&, [], [0]}, :uniqueMember]}, [], []}]}, ['uid=manny,ou=users,dc=puppetlabs,dc=com']
+  defp translate_ecto_lisp_to_eldap_filter({op, [], [{:^, [], [idx]}, value2]}, params) do
+    translate_ecto_lisp_to_eldap_filter({op, [], [Enum.at(params, idx), value2]}, params)
+  end
 
   defp translate_ecto_lisp_to_eldap_filter({:ilike, _, [value1, "%" <> value2]}, _) do
     like_with_leading_wildcard(value1, value2)

--- a/lib/ecto_ldap/adapter.ex
+++ b/lib/ecto_ldap/adapter.ex
@@ -220,12 +220,17 @@ defmodule Ecto.Ldap.Adapter do
     case select.fields do
       [{:&, [], [0]}] -> 
         { :attributes,
-          sources |> ordered_fields |> Enum.map(&convert_to_erlang/1) }
+          sources
+          |> ordered_fields
+          |> List.flatten
+          |> Enum.map(&convert_to_erlang/1)
+        }
       attributes -> 
         {
           :attributes,
           attributes
           |> Enum.map(&extract_select/1)
+          |> List.flatten
           |> Enum.map(&convert_to_erlang/1)
         }
     end
@@ -396,7 +401,7 @@ defmodule Ecto.Ldap.Adapter do
     model.__schema__(:fields)
   end
 
-  def count_fields(fields, sources) when is_list(fields), do: fields |> Enum.map(fn field -> count_fields(field, sources) end)
+  def count_fields(fields, sources) when is_list(fields), do: fields |> Enum.map(fn field -> count_fields(field, sources) end) |> List.flatten
   def count_fields({{_, _, fields}, _, _}, sources), do: fields |> extract_field_info(sources)
   def count_fields({:&, _, [_idx]} = field, sources), do: extract_field_info(field, sources)
 
@@ -416,14 +421,14 @@ defmodule Ecto.Ldap.Adapter do
       end))
   end
 
-  defp prune_attributes(attributes, _all_fields, [{[{:&, [], [0]}, field], _}]), do: Keyword.get(attributes, field)
   defp prune_attributes(attributes, all_fields, [{{:&, [], [0]}, _}] = _selected_fields) do
     for field <- all_fields, do: Keyword.get(attributes, field)
   end
   defp prune_attributes(attributes, _all_fields, selected_fields) do
-    for [{[{:&, [], [0]}, field], _}] <- selected_fields do
+    selected_fields
+    |> Enum.map(fn {[{:&, [], _}, field], _} ->
       Keyword.get(attributes, field)
-    end
+      end)
   end
 
   defp generate_models(row, preprocess, [{:&, [], [_idx, _columns, _count]}] = fields), do:

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule EctoLdap.Mixfile do
 
   def project do
     [app: :ecto_ldap,
-     version: "0.3.0",
+     version: "0.3.1",
      elixir: "~> 1.3",
      name: "ecto_ldap",
      description: @description,

--- a/test/ecto_ldap_test.exs
+++ b/test/ecto_ldap_test.exs
@@ -230,6 +230,12 @@ defmodule EctoLdapTest do
     assert values == [["jeff.weiss", ['5001']], ["manny", ['5002']]]
   end
 
+  test "query for bound variable in array attribute" do
+    obj = "posixAccount"
+    values = TestRepo.all(Ecto.Query.from(u in TestUser, where: ^obj in u.objectClass))
+    assert Enum.count(values) == 2
+  end
+
   test "delete_all unsupported" do
     assert_raise RuntimeError, fn ->
       TestRepo.delete_all(TestUser, dn: "uid=manny,ou=users,dc=example,dc=com")

--- a/test/ecto_ldap_test.exs
+++ b/test/ecto_ldap_test.exs
@@ -195,6 +195,41 @@ defmodule EctoLdapTest do
     assert Enum.count(values) == 2
   end
 
+  test "query for one record using a single select argument returns single attribute in a list" do
+    values = TestRepo.all(Ecto.Query.from(u in TestUser, where: u.uid == "jeff.weiss", select: u.st))
+    assert values == ["OR"]
+  end
+
+  test "query for one record using a single select argument returns an array attribute as a list inside a list" do
+    values = TestRepo.all(Ecto.Query.from(u in TestUser, where: u.uid == "jeff.weiss", select: u.skills))
+    assert values == [["dad jokes", "being awesome", "elixir"]]
+  end
+
+  test "query for one record using a single-entry list argument for select returns an array attribute as a list inside a list of lists" do
+    values = TestRepo.all(Ecto.Query.from(u in TestUser, where: u.uid == "jeff.weiss", select: [u.skills]))
+    assert values == [[["dad jokes", "being awesome", "elixir"]]]
+  end
+
+  test "query for one record using a single-entry list argument for select returns single attribute in a list of lists" do
+    values = TestRepo.all(Ecto.Query.from(u in TestUser, where: u.uid == "jeff.weiss", select: [u.st]))
+    assert values == [["OR"]]
+  end
+
+  test "query for a single attribute across multiple records returns selected attribute in a list" do
+    values = TestRepo.all(Ecto.Query.from(u in TestUser, where: u.st == "OR", select: u.uid))
+    assert values == ["jeff.weiss", "manny"]
+  end
+
+  test "query for single attribute as a single-entry list argument for select across multiple records returns selected attribute in a list of lists" do
+    values = TestRepo.all(Ecto.Query.from(u in TestUser, where: u.st == "OR", select: [u.uid]))
+    assert values == [["jeff.weiss"], ["manny"]]
+  end
+
+  test "query for multiple attributes across multiple records returns selected attributes in a list of lists" do
+    values = TestRepo.all(Ecto.Query.from(u in TestUser, where: u.st == "OR", select: [u.uid, u.uidNumber]))
+    assert values == [["jeff.weiss", ['5001']], ["manny", ['5002']]]
+  end
+
   test "delete_all unsupported" do
     assert_raise RuntimeError, fn ->
       TestRepo.delete_all(TestUser, dn: "uid=manny,ou=users,dc=example,dc=com")


### PR DESCRIPTION
Prior to this commit, use of the `:select` query criteria resulted in a
failure of the `ecto_ldap` adapter to return results due to a mismatched
function head expectation.

This commit resolves the bug by conforming the expected data to use
flattened lists instead of lists-of-lists, as well as consistent pruning
of the selected attributes to be returned from the adapter.

Tests which exercise the expected response have been added to ensure
proper functioning going forward.
